### PR TITLE
Fix status/type selectors

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -327,36 +327,16 @@ myModule.factory('UsersService', function ($http, $q, AuthService, ENDPOINT_URI)
 });
 
 
-myModule.factory('HelperService', function () {
-    var buildIndex = function (source, property) {
-        var tempArray = [];
-
-        for (var i = 0, len = source.length; i < len; ++i) {
-            tempArray[source[i][property]] = source[i];
-        }
-
-        return tempArray;
-    };
-
-    return {
-        buildIndex: buildIndex
-    };
-});
-
-myModule.controller('StoryboardCtrl', ['$scope', 'StoriesService', 'HelperService', 'UsersService', 'STORY_STATUSES', 'STORY_TYPES',
-    function ($scope, StoriesService, HelperService, UsersService, STORY_STATUSES, STORY_TYPES) {
+myModule.controller('StoryboardCtrl', ['$scope', 'StoriesService', 'UsersService', 'STORY_STATUSES', 'STORY_TYPES',
+    function ($scope, StoriesService, UsersService, STORY_STATUSES, STORY_TYPES) {
         $scope.detailsVisible = true;
         $scope.currentStoryId = null;
         $scope.currentStory = null;
-        $scope.currentStatus = null;
-        $scope.currentType = null;
         $scope.editedStory = {};
         $scope.stories = [];
 
         $scope.types = STORY_TYPES;
         $scope.statuses = STORY_STATUSES;
-        $scope.typesIndex = HelperService.buildIndex($scope.types, 'name');
-        $scope.statusesIndex = HelperService.buildIndex($scope.statuses, 'name');
 
         $scope.users = {};
 
@@ -371,9 +351,6 @@ myModule.controller('StoryboardCtrl', ['$scope', 'StoriesService', 'HelperServic
             $scope.currentStoryId = id;
             $scope.currentStory = story;
             $scope.editedStory = angular.copy($scope.currentStory);
-
-            $scope.currentStatus = $scope.statusesIndex[story.status];
-            $scope.currentType = $scope.typesIndex[story.type];
         };
 
         $scope.getStories = function () {
@@ -414,19 +391,9 @@ myModule.controller('StoryboardCtrl', ['$scope', 'StoriesService', 'HelperServic
 
         $scope.resetForm = function () {
             $scope.currentStory = null;
-            $scope.currentStatus = null;
-            $scope.currentType = null;
             $scope.editedStory = {};
 
             $scope.detailsForm.$setPristine();
-        };
-
-        $scope.setCurrentStatus = function (status) {
-            $scope.editedStory.status = status.name;
-        };
-
-        $scope.setCurrentType = function (type) {
-            $scope.editedStory.type = type.name;
         };
 
         $scope.setDetailsVisible = function (visible) {

--- a/app/partials/storyboard.html
+++ b/app/partials/storyboard.html
@@ -51,7 +51,7 @@
                 <label class="control-label" for="inputStatus">*Status</label>
 
                 <div class="controls">
-                    <select id="inputStatus" name="inputStatus" class="form-control" ng-model="currentStatus" ng-options="l.name for l in statuses" ng-change="setCurrentStatus(currentStatus)" ng-required="true">
+                    <select id="inputStatus" name="inputStatus" class="form-control" ng-model="editedStory.status" ng-options="l.name as l.name for l in statuses" ng-required="true">
                         <option value="">Select Status</option>
                     </select>
 
@@ -64,7 +64,7 @@
                 <label class="control-label" for="inputType">*Type</label>
 
                 <div class="controls">
-                    <select id="inputType" name="inputType" class="form-control" ng-model="currentType" ng-options="t.name for t in types" ng-change="setCurrentType(currentType)" ng-required="true">
+                    <select id="inputType" name="inputType" class="form-control" ng-model="editedStory.type" ng-options="t.name as t.name for t in types" ng-required="true">
                         <option value="">Select Type</option>
                     </select>
 


### PR DESCRIPTION
The `ng-model` directives for the status and type selectors was set to a primitive with no object accessor, which was breaking due to the use of `ng-if`. This change modifies those properties directly on `editedStory` and removes the now unused `HelperService`.

@simpulton Pending your review.
